### PR TITLE
Ensure that mocha uses testListeners in Test

### DIFF
--- a/src/main/scala/com/typesafe/sbt/mocha/SbtMocha.scala
+++ b/src/main/scala/com/typesafe/sbt/mocha/SbtMocha.scala
@@ -162,7 +162,7 @@ object SbtMocha extends AutoPlugin {
       val results = SbtJsTask.executeJs(state.value, (engineType in mocha).value, (command in mocha).value, modules, (shellSource in mocha).value,
         Seq(jsOptions, JsArray(tests.map(t => JsString.apply(t.getCanonicalPath)).toList).toString()), 100.days)
 
-      val listeners = (testListeners in mocha).value
+      val listeners = (testListeners in (Test, mocha)).value
 
       results.headOption.map { jsResults =>
         new MochaTestReporting(workDir, listeners).logTestResults(jsResults)

--- a/src/sbt-test/sbt-mocha-plugin/test/project/TestBuild.scala
+++ b/src/sbt-test/sbt-mocha-plugin/test/project/TestBuild.scala
@@ -86,6 +86,7 @@ object TestBuild extends Build {
       TestLogger.messages = Nil
       TestLogger.exceptions = Nil
       TestLogger.successes = Nil
+      MockListener.gotAnEvent = false
     },
 
     TaskKey[Unit]("no-errors") := {
@@ -98,8 +99,26 @@ object TestBuild extends Build {
       if (!TestLogger.exceptions.isEmpty) {
         throw new RuntimeException("Expected no exceptions, but got:\n" + TestLogger.exceptions.reverse.mkString("\n"))
       }
-    }
+    },
 
+    TaskKey[Unit]("mock-listener-invoked") := {
+      if (!MockListener.gotAnEvent) {
+        throw new RuntimeException("Mock test report listener was not invoked")
+      }
+    }
   )
+
+  object MockListener extends TestReportListener {
+
+    @volatile var gotAnEvent = false
+
+    def testEvent(event: TestEvent) = gotAnEvent = true
+
+    def startGroup(name: String) = ()
+
+    def endGroup(name: String, t: Throwable) = ()
+
+    def endGroup(name: String, result: TestResult.Value) = ()
+  }
 
 }

--- a/src/sbt-test/sbt-mocha-plugin/test/test
+++ b/src/sbt-test/sbt-mocha-plugin/test/test
@@ -59,6 +59,22 @@
 
 > reset-logs
 
+# Custom test listeners
+> set testListeners += TestBuild.MockListener
+> mocha-only HappyAssetSpec
+> mock-listener-invoked
+
+> set testListeners := testListeners.value.filterNot(_ == TestBuild.MockListener)
+> reset-logs
+
+# Activator configures testListeners in Test, so the below needs to work
+> set (testListeners in Test) += TestBuild.MockListener
+> mocha-only HappyAssetSpec
+> mock-listener-invoked
+
+> set testListeners := testListeners.value.filterNot(_ == TestBuild.MockListener)
+> reset-logs
+
 # Run all mocha tests
 -> mocha
 > logged error "Error: Total 6, Failed 1, Errors 1, Passed 4"


### PR DESCRIPTION
Activator adds a test report listener to testListeners in the Test scope in order to listen and report on tests in the UI, without this change, Activator UI doesn't correctly report mocha tests.
