### PR TITLE
JSON.stringify actual and expected in failure reports.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/mocha/mocha.js
+++ b/src/main/resources/com/typesafe/sbt/mocha/mocha.js
@@ -56,7 +56,7 @@ function MyReporter(runner) {
                 error: {
                     name: err.name,
                     message: (err.message ? err.message + ": " : "") +
-                        "Got value " + err.actual + " but expected a value " + err.operator + " " + err.expected,
+                        "Got value " + JSON.stringify(err.actual) + " but expected a value " + err.operator + " " + JSON.stringify(err.expected),
                     stack: err.stack
                 }
             })


### PR DESCRIPTION
This is in order to see the contents of the differing objects and avoid the ugliness of [Object object] in the output.