### PR TITLE
Upgrade to newer version of sbt-js-engine

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
-jdk: openjdk6
+jdk: openjdk7
 language: scala
 script: sbt scripted

--- a/build.sbt
+++ b/build.sbt
@@ -4,13 +4,13 @@ organization := "com.typesafe.sbt"
 name := "sbt-mocha"
 description := "sbt mocha support"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.10.5"
 sbtPlugin := true
 
 libraryDependencies ++= Seq(
   "org.webjars" % "mocha" % "1.17.1"
 )
-addSbtPlugin("com.typesafe.sbt" % "sbt-js-engine" % "1.1.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-js-engine" % "1.1.3")
 
 scriptedSettings
 scriptedLaunchOpts <+= version apply { v => s"-Dproject.version=$v" }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,6 +2,4 @@ libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8.5")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("com.eed3si9n" % "bintray-sbt" % "0.3.0-a1934a5457f882053b08cbdab5fd4eb3c2d1285d")
-resolvers += Resolver.url("bintray-eed3si9n-sbt-plugins", url("https://dl.bintray.com/eed3si9n/sbt-plugins/"))(Resolver.ivyStylePatterns)
-
+addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")

--- a/src/sbt-test/sbt-mocha-plugin/multi-module/project/build.properties
+++ b/src/sbt-test/sbt-mocha-plugin/multi-module/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.8

--- a/src/sbt-test/sbt-mocha-plugin/test/project/build.properties
+++ b/src/sbt-test/sbt-mocha-plugin/test/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5-RC3
+sbt.version=0.13.8


### PR DESCRIPTION
This PR should fix a number of problems that people have with sbt-mocha

@eed3si9n is it recommended to change from `"com.eed3si9n" % "bintray-sbt" % "0.3.0-a1934a5457f882053b08cbdab5fd4eb3c2d1285d"` to `"me.lessis" % "bintray-sbt" % "0.3.0"` as I'm doing here?