### PR TITLE
Remove hard exits since status:"error" is returned and used to detect failed tests

### DIFF
--- a/src/main/resources/com/typesafe/sbt/mocha/mocha.js
+++ b/src/main/resources/com/typesafe/sbt/mocha/mocha.js
@@ -90,7 +90,6 @@ function MyReporter(runner) {
             });
         }
         console.log("\u0010", JSON.stringify(currentSuite[0]));
-        process.exit(0);
     });
 }
 
@@ -125,6 +124,4 @@ if (options.checkLeaks) {
 }
 
 mocha.files = tests;
-mocha.run(function(code) {
-    process.exit(code);
-});
+mocha.run();


### PR DESCRIPTION
- These hard exits prevent the node process from writing out the entire
  JSON for really large test suites since they generate errors over 65536
  in stringly length. V8 uses 65536 as its buffer size in many places, so
  node inherits this. A hard process.exit prevents any chunks past the first
  made by the console.log(JSON.stringify(currentSuite)) to be printed,
  sending an incomplete object back to the parent process via stdout.
- try the below to emulate the issue, run the below, and notice that the
  JSON object is cut off and is invalid JSON
    `node -e "console.log(JSON.stringify({val: 'big string repeated'.repeat(20000)})); process.exit(1)" | cat`
