### PR TITLE
Handle multiple extracted versions of same webjar

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,10 @@ developers += Developer(
 
 addSbtJsEngine("1.3.5")
 
-libraryDependencies += "org.webjars" % "mocha" % "1.17.1"
+libraryDependencies ++= Seq(
+  "org.webjars.npm" % "node-require-fallback" % "1.0.0",
+  "org.webjars" % "mocha" % "1.17.1", // sync with src/main/resources/com/typesafe/sbt/mocha/mocha.js
+)
 
 // Customise sbt-dynver's behaviour to make it work with tags which aren't v-prefixed
 ThisBuild / dynverVTagPrefix := false

--- a/src/main/resources/com/typesafe/sbt/mocha/mocha.js
+++ b/src/main/resources/com/typesafe/sbt/mocha/mocha.js
@@ -1,4 +1,6 @@
-var Mocha = require("mocha");
+var requireIfExists = require('node-require-fallback');
+
+var Mocha = requireIfExists("mocha/1.17.1", "mocha"); // sync with build.sbt
 
 var mocha = new Mocha();
 

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/build.sbt
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/build.sbt
@@ -1,0 +1,64 @@
+enablePlugins(SbtWeb)
+
+Keys.libraryDependencies += "org.specs2" %% "specs2-core" % "4.20.4" % "test"
+
+MochaKeys.requires += "Setup"
+scalaVersion := "2.13.12"
+
+Global / Keys.extraLoggers := { scope =>
+  // Configure extra loggers just for the mocha and test tasks
+  if (scope.scope.task.fold({ tsk =>
+    Seq(
+      MochaKeys.mochaOnly.key,
+      MochaKeys.mocha.key,
+      MochaKeys.mochaExecuteTests,
+      Keys.test.key
+    ).contains(tsk)
+  }, false, false)) {
+    Seq(TestLogger)
+  } else {
+    Nil
+  }
+}
+
+InputKey[Unit]("logged") := {
+  val args = Def.spaceDelimited("<level> <msg>").parsed
+  val level = Level.withName(args.head)
+  val msg = args.tail.head
+
+  val msgs = TestLogger.messages.collect {
+    case (l, m) if m.trim == msg => l
+  }
+
+  if (msgs.contains(level)) {
+    // Pass
+  } else if (msgs.isEmpty) {
+    throw new RuntimeException("No test logged with content '" + msg + "' messages were:\n" + TestLogger.messages.reverse.mkString("\n"))
+  } else {
+    throw new RuntimeException("No test logged with content '" + msg + "' at level " + level + ", but some matched at level(s) " + msgs)
+  }
+}
+
+TaskKey[Unit]("resetLogs") := {
+  TestLogger.messages = Nil
+  TestLogger.exceptions = Nil
+  MockListener.gotAnEvent = false
+}
+
+TaskKey[Unit]("noErrors") := {
+  val errors = TestLogger.messages.filter {
+    case (l, m) => l == Level.Error || l == Level.Warn
+  }
+  if (!errors.isEmpty) {
+    throw new RuntimeException("Expected no errors, but got:\n" + errors.reverse.mkString("\n"))
+  }
+  if (!TestLogger.exceptions.isEmpty) {
+    throw new RuntimeException("Expected no exceptions, but got:\n" + TestLogger.exceptions.reverse.mkString("\n"))
+  }
+}
+
+TaskKey[Unit]("mockListenerInvoked") := {
+  if (!MockListener.gotAnEvent) {
+    throw new RuntimeException("Mock test report listener was not invoked")
+  }
+}

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/project/MockListener.scala
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/project/MockListener.scala
@@ -1,0 +1,14 @@
+import sbt._
+
+object MockListener extends TestReportListener {
+
+  @volatile var gotAnEvent = false
+
+  def testEvent(event: TestEvent) = gotAnEvent = true
+
+  def startGroup(name: String) = ()
+
+  def endGroup(name: String, t: Throwable) = ()
+
+  def endGroup(name: String, result: TestResult) = ()
+}

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/project/plugins.sbt
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/project/plugins.sbt
@@ -1,0 +1,18 @@
+addSbtPlugin("com.github.sbt" % "sbt-mocha" % sys.props("project.version"))
+
+// When the same webjar (= same name) from different groupIds (org.webjars[.npm|bower]?)
+// are are on the classpath, those webjars get extracted into subfolders which are named by the version of the webjar.
+// However, if there is just one type (npm, bower, classic) of a webjar on the classpath, NO subfolders gets created.
+// Now, because in a project we don't know which other webjars get pulled in from other dependencies, it can happen
+// that subfolders get created, or may not. However, require(...) can't know that and therefore has to look in both places.
+// To test that the lookup is correct, we force this scripted test to create subfolders by pulling in the same webjar
+// but from different groupIds (the other scripted test does not do that and therefore no subfolders get created there)
+// btw: dependency eviction within the same type of webjar still works correctly, so e.g. 0.2 wins over 0.1 within the same type of webjar
+// and no subfolder will be forced for that case but the newest version will be choosen. Like normal dependency resolution.
+libraryDependencies ++= Seq(
+  // Pulling in the classic and the npm webjar to subfolders for this webjar will be created
+  ("org.webjars.npm" % "mocha" % "3.0.0-2")
+    .exclude("org.webjars.npm", "debug")
+    .exclude("org.webjars.npm", "diff"),
+  "org.webjars" % "mocha" % "1.17.1",
+)

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/project/src/main/scala/TestLogger.scala
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/project/src/main/scala/TestLogger.scala
@@ -1,0 +1,49 @@
+import org.apache.logging.log4j.core._
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.core.layout.PatternLayout
+import org.apache.logging.log4j.message.ObjectMessage
+import sbt.internal.util.{ObjectEvent, StringEvent}
+import sbt.{Level => SbtLevel}
+
+object TestLogger extends AbstractAppender("TestLogger", null, PatternLayout.createDefaultLayout(), true) {
+
+  override def append(event: LogEvent): Unit = {
+    val level = event.getLevel match {
+      case Level.ERROR => SbtLevel.Error
+      case Level.WARN => SbtLevel.Warn
+      case Level.INFO => SbtLevel.Info
+    }
+    val msg = event.getMessage match {
+      case o: ObjectMessage =>
+        o.getParameter match {
+          case e: ObjectEvent[_] => e.message.toString
+          case s: StringEvent => s.message
+          case _ => event.getMessage.getFormattedMessage
+        }
+      case _ => event.getMessage.getFormattedMessage
+    }
+    messages = (level, stripAnsiCodes(msg)) :: messages
+
+    if (event.getMessage.getThrowable != null) {
+      exceptions = event.getMessage.getThrowable :: exceptions
+    }
+  }
+
+  override def error(msg: String): Unit = messages = (SbtLevel.Error, msg) :: messages
+  override def error(msg: String, t: Throwable): Unit = {
+    exceptions = t :: exceptions
+    error(msg)
+  }
+  override def error(msg: String, event: LogEvent, t: Throwable): Unit = {
+    exceptions = t :: exceptions
+    append(event)
+  }
+
+  def stripAnsiCodes(s: String): String = {
+    s.replaceAll("\u001b[^m]*m", "")
+  }
+
+  var messages = List.empty[(SbtLevel.Value, String)]
+  var exceptions = List.empty[Throwable]
+}

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/main/assets/HappyAsset.js
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/main/assets/HappyAsset.js
@@ -1,0 +1,3 @@
+module.exports.foo = function() {
+    console.log("I am imported");
+};

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/main/assets/MainAsset.js
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/main/assets/MainAsset.js
@@ -1,0 +1,5 @@
+describe("a test asset", function() {
+    it("should be happy", function() {
+        console.log("I am happy");
+    });
+});

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/main/public/HappyPublic.js
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/main/public/HappyPublic.js
@@ -1,0 +1,3 @@
+module.exports.foo = function() {
+    console.log("I am imported");
+};

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/ErrorSpec.js
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/ErrorSpec.js
@@ -1,0 +1,5 @@
+describe("a spec", function() {
+    it("should be able to fail with a generic error", function() {
+        throw new Error("not happy");
+    });
+});

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/FailingSpec.js
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/FailingSpec.js
@@ -1,0 +1,5 @@
+describe("a spec", function() {
+   it("should be able to fail with an assertion error", function() {
+      require("assert").equal(true, false);
+   });
+});

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/HappyAssetSpec.js
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/HappyAssetSpec.js
@@ -1,0 +1,11 @@
+describe("a test asset", function() {
+    it("should be happy", function() {
+        console.log("I am happy");
+    });
+    it("should be able to require a main asset", function() {
+        require("./HappyAsset").foo();
+    });
+    it("should be able to require a main resource", function() {
+        require("./HappyPublic").foo();
+    });
+});

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/Setup.js
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/Setup.js
@@ -1,0 +1,3 @@
+global.myGlobal = function() {
+    return "is set";
+};

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/SetupSpec.js
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/assets/SetupSpec.js
@@ -1,0 +1,5 @@
+describe("setup", function() {
+   it("should have been required", function() {
+       require("assert").equal(myGlobal(), "is set");
+   });
+});

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/public/HappyPublicSpec.js
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/public/HappyPublicSpec.js
@@ -1,0 +1,5 @@
+describe("a test resource", function() {
+    it("should be happy", function() {
+        console.log("I am happy");
+    });
+});

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/scala/Specs2Spec.scala
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/src/test/scala/Specs2Spec.scala
@@ -1,0 +1,18 @@
+package specsspec
+
+import org.specs2.mutable._
+
+object HelloWorldSpec extends Specification {
+
+  "The 'Hello world' string" should {
+    "contain 11 characters" in {
+      "Hello world" must have size(11)
+    }
+    "start with 'Hello'" in {
+      "Hello world" must startWith("Hello")
+    }
+    "end with 'world'" in {
+      "Hello world" must endWith("world")
+    }
+  }
+}

--- a/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/test
+++ b/src/sbt-test/sbt-mocha-plugin/test-same-webjars-different-version/test
@@ -81,4 +81,5 @@
 -> test
 > logged error "Error: Total 9, Failed 1, Errors 1, Passed 7"
 
-$ exists project/target/node-modules/webjars/mocha/index.js
+$ exists project/target/node-modules/webjars/mocha/1.17.1
+$ exists project/target/node-modules/webjars/mocha/3.0.0-2


### PR DESCRIPTION
Those webjars get extracted in subfolders.

See lengthy comment in `plugins.sbt` of this pull request.

- Same as in https://github.com/sbt/sbt-coffeescript/pull/33
- https://github.com/sbt/sbt-less/pull/128
- https://github.com/sbt/sbt-jshint/pull/58

Also see
- https://github.com/webjars/webjars-locator-core/issues/141 (specially "Side note on creating subfolders")